### PR TITLE
cicd: build push image on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,38 +11,20 @@ jobs:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Appclacks Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build/Push image ghcr.io/mcorbin/cabourotte:latest
+          username: ${{ secrets.DOCKERHUB_LOGIN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build/Push image appclacks/cabourotte:latest
         shell: /usr/bin/bash {0}
         run: |
-          docker build . -t ghcr.io/mcorbin/cabourotte:latest
-          docker push       ghcr.io/mcorbin/cabourotte:latest
+          docker build . -t appclacks/cabourotte:latest
+          docker push       appclacks/cabourotte:latest
           # get tags of current commit
           tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
           if [ ! -z "$tag" ]; then
             echo "Tag name from git describe: $tag"
-            docker tag  ghcr.io/mcorbin/cabourotte:latest ghcr.io/mcorbin/cabourotte:$tag
-            docker push ghcr.io/mcorbin/cabourotte:$tag
+            docker tag  appclacks/cabourotte:latest appclacks/cabourotte:$tag
+            docker push appclacks/cabourotte:$tag
           fi
-      - name: Login to Docker Container Registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ vars.DOCKERHUB_LOGIN }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Tag and Push image to docker registry
-        shell: /usr/bin/bash {0}
-        run: |
-            docker tag ghcr.io/mcorbin/cabourotte:latest mcorbin/cabourotte:latest
-            docker push       mcorbin/cabourotte:latest
-            # get tags of current commit
-            tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
-            if [ ! -z "$tag" ]; then
-              echo "Tag name from git describe: $tag"
-              docker tag  ghcr.io/mcorbin/cabourotte:latest mcorbin/cabourotte:$tag
-              docker push mcorbin/cabourotte:$tag
-            fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: publish docker image
+on: 
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build/Push image ghcr.io/mcorbin/cabourotte:latest
+        shell: /usr/bin/bash {0}
+        run: |
+          docker build . -t ghcr.io/mcorbin/cabourotte:latest
+          docker push       ghcr.io/mcorbin/cabourotte:latest
+          # get tags of current commit
+          tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+          if [ ! -z "$tag" ]; then
+            echo "Tag name from git describe: $tag"
+            docker tag  ghcr.io/mcorbin/cabourotte:latest ghcr.io/mcorbin/cabourotte:$tag
+            docker push ghcr.io/mcorbin/cabourotte:$tag
+          fi
+      - name: Login to Docker Container Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKERHUB_LOGIN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Tag and Push image to docker registry
+        shell: /usr/bin/bash {0}
+        run: |
+            docker tag ghcr.io/mcorbin/cabourotte:latest mcorbin/cabourotte:latest
+            docker push       mcorbin/cabourotte:latest
+            # get tags of current commit
+            tag=$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))
+            if [ ! -z "$tag" ]; then
+              echo "Tag name from git describe: $tag"
+              docker tag  ghcr.io/mcorbin/cabourotte:latest mcorbin/cabourotte:$tag
+              docker push mcorbin/cabourotte:$tag
+            fi


### PR DESCRIPTION
This PR add a job to build and push docker image on docker hub and also on github.

To push on docker hub, you will have to setup (settings/secrets and variables / actions) :

* an environment variable: DOCKERHUB_LOGIN
* a secret: DOCKERHUB_PASSWORD

I'm not very familiar with github actions. I'm waiting for your comments.

Best regards