### PR TITLE
Enclose HTTP listener address in brackets to allow for IPv6 addresses

### DIFF
--- a/http/root.go
+++ b/http/root.go
@@ -107,7 +107,7 @@ func New(logger *zap.Logger, memstore *memorystore.MemoryStore, promComponent *p
 
 // Start starts the http server
 func (c *Component) Start() error {
-	address := fmt.Sprintf("%s:%d", c.Config.Host, c.Config.Port)
+	address := fmt.Sprintf("[%s]:%d", c.Config.Host, c.Config.Port)
 	c.Logger.Info(fmt.Sprintf("Starting the HTTP server component on %s", address))
 	c.handlers()
 	err := c.Prometheus.Register(c.responseCounter)


### PR DESCRIPTION
The HTTP listener currently does not support IPv6 addresses due to colon(`:`) ambiguity:
```
{"level":"error","ts":1694782381.9328856,"caller":"http/root.go:136","msg":"HTTP server error: listen tcp: address ::1:9013: too many colons in address","stacktrace":"github.com/appclacks/cabourotte/http.(*Component).Start.func1\n\t/go/cabourotte/http/root.go:136"}
```

This PR simply adds `[]` so the address/port combination can be parsed correctly and has no effect on IPv4 listeners.