### PR TITLE
fix panic when a not present assets is called

### DIFF
--- a/exporter/riemann.go
+++ b/exporter/riemann.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -156,6 +157,11 @@ func (c *RiemannExporter) Push(result *healthcheck.Result) error {
 	}
 	for k, v := range result.Labels {
 		attributes[k] = v
+	}
+	for k, v := range result.Annotations {
+		k = strings.ToLower(k)
+		k = strings.TrimSpace(k)
+		attributes[strings.ToLower(k)] = v
 	}
 	event := &riemanngo.Event{
 		Service:     "cabourotte-healthcheck",

--- a/healthcheck/command.go
+++ b/healthcheck/command.go
@@ -107,7 +107,7 @@ func (h *CommandHealthcheck) LogInfo(message string) {
 }
 
 // Execute executes an healthcheck on the given domain
-func (h *CommandHealthcheck) Execute() error {
+func (h *CommandHealthcheck) Execute() ExecutionError {
 	h.LogDebug("start executing healthcheck")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(h.Config.Timeout)*time.Second)
 	defer cancel()
@@ -122,10 +122,10 @@ func (h *CommandHealthcheck) Execute() error {
 		} else {
 			errorMsg = fmt.Sprintf("The command failed, stderr=%s", stdErr.String())
 		}
-		return errors.Wrapf(err, errorMsg)
+		return ExecutionError{Error: errors.Wrapf(err, errorMsg)}
 	}
 
-	return nil
+	return ExecutionError{Error: nil}
 }
 
 // NewCommandHealthcheck creates a Command healthcheck from a logger and a configuration

--- a/healthcheck/command_test.go
+++ b/healthcheck/command_test.go
@@ -15,9 +15,9 @@ func TestCommandExecuteSuccess(t *testing.T) {
 			Timeout: Duration(time.Second * 2),
 		},
 	}
-	err := h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 }
 
@@ -30,8 +30,8 @@ func TestCommandExecuteFailure(t *testing.T) {
 			Timeout:   Duration(time.Second * 2),
 		},
 	}
-	err := h.Execute()
-	if err == nil {
+	eErr := h.Execute()
+	if eErr.Error == nil {
 		t.Fatalf("healthcheck was expected to fail")
 	}
 }

--- a/healthcheck/dns.go
+++ b/healthcheck/dns.go
@@ -150,17 +150,17 @@ func (h *DNSHealthcheck) lookupIP() ([]net.IP, error) {
 }
 
 // Execute executes an healthcheck on the given domain
-func (h *DNSHealthcheck) Execute() error {
+func (h *DNSHealthcheck) Execute() ExecutionError {
 	h.LogDebug("start executing healthcheck")
 	ips, err := h.lookupIP()
 	if err != nil {
-		return errors.Wrapf(err, "Fail to lookup IP for domain")
+		return ExecutionError{Error: errors.Wrapf(err, "Fail to lookup IP for domain")}
 	}
 	err = verifyIPs(h.Config.ExpectedIPs, ips)
 	if err != nil {
-		return err
+		return ExecutionError{Error: err}
 	}
-	return nil
+	return ExecutionError{Error: nil}
 }
 
 // NewDNSHealthcheck creates a DNS healthcheck from a logger and a configuration

--- a/healthcheck/dns_test.go
+++ b/healthcheck/dns_test.go
@@ -20,9 +20,9 @@ func TestDNSExecuteSuccess(t *testing.T) {
 		},
 	}
 
-	err := h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 }
 
@@ -35,8 +35,8 @@ func TestDNSExecuteFailure(t *testing.T) {
 		},
 	}
 
-	err := h.Execute()
-	if err == nil {
+	eErr := h.Execute()
+	if eErr.Error == nil {
 		t.Fatalf("Was expecting an error: the domain does not exist")
 	}
 }

--- a/healthcheck/http.go
+++ b/healthcheck/http.go
@@ -252,7 +252,8 @@ func (h *HTTPHealthcheck) Execute() ExecutionError {
 	message := responseBodyStr
 
 	var eErr ExecutionError
-	eErr.HTTPStatusCode = response.StatusCode
+	eErr.Annotations = make(map[string]string)
+	eErr.Annotations["HTTP Status Code"] = fmt.Sprintf("%v", response.StatusCode)
 	if len(responseBodyStr) > maxMessageSize {
 		message = responseBodyStr[0:maxMessageSize]
 	}

--- a/healthcheck/http_test.go
+++ b/healthcheck/http_test.go
@@ -104,9 +104,9 @@ func TestHTTPExecuteGetSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 	if count != 1 {
 		t.Fatal("The request counter is invalid")
@@ -154,9 +154,9 @@ func TestHTTPExecuteRegexpSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 	if count != 1 {
 		t.Fatal("The request counter is invalid")
@@ -198,8 +198,8 @@ func TestHTTPExecuteRegexpFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err == nil {
+	eErr := h.Execute()
+	if eErr.Error == nil {
 		t.Fatalf("Was expecting an error")
 	}
 
@@ -240,9 +240,9 @@ func TestHTTPv6ExecuteSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 	if count != 1 {
 		t.Fatalf("The request counter is invalid")
@@ -279,8 +279,8 @@ func TestHTTPExecuteFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err == nil {
+	eErr := h.Execute()
+	if eErr.Error == nil {
 		t.Fatalf("Was expecting an error")
 	}
 	if count != 1 {
@@ -407,9 +407,9 @@ func TestHTTPExecuteSourceIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 	if count != 1 {
 		t.Fatal("The request counter is invalid")
@@ -470,9 +470,9 @@ func TestHTTPExecutePostSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 	if count != 1 {
 		t.Fatal("The request counter is invalid")
@@ -546,9 +546,9 @@ func TestHTTPExecuteQueryParam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialization error :\n%v", err)
 	}
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 	if count != 1 {
 		t.Fatal("The request counter is invalid")

--- a/healthcheck/result.go
+++ b/healthcheck/result.go
@@ -14,6 +14,8 @@ type Result struct {
 	Message              string            `json:"message"`
 	Duration             int64             `json:"duration"`
 	Source               string            `json:"source"`
+	HTTPError            string            `json:"http-error"`
+	HTTPStatusCode       int64             `json:"http-status-code"`
 }
 
 // Equals implements Equals for Result
@@ -39,6 +41,9 @@ func (r Result) Equals(v Result) bool {
 	if r.Source != v.Source {
 		return false
 	}
+	if r.HTTPStatusCode != v.HTTPStatusCode {
+		return false
+	}
 	if len(r.Labels) != len(v.Labels) {
 		return false
 	}
@@ -51,7 +56,7 @@ func (r Result) Equals(v Result) bool {
 }
 
 // NewResult build a a new result for an healthcheck
-func NewResult(healthcheck Healthcheck, duration int64, err error) *Result {
+func NewResult(healthcheck Healthcheck, duration int64, eErr ExecutionError) *Result {
 	now := time.Now()
 	source := "configuration"
 	if healthcheck.Base().Source != "" {
@@ -64,10 +69,11 @@ func NewResult(healthcheck Healthcheck, duration int64, err error) *Result {
 		HealthcheckTimestamp: now.Unix(),
 		Duration:             duration,
 		Source:               source,
+		HTTPStatusCode:       int64(eErr.HTTPStatusCode),
 	}
-	if err != nil {
+	if eErr.Error != nil {
 		result.Success = false
-		result.Message = err.Error()
+		result.Message = eErr.Error.Error()
 	} else {
 		result.Success = true
 		result.Message = "success"

--- a/healthcheck/result.go
+++ b/healthcheck/result.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"reflect"
 	"time"
 )
 
@@ -14,8 +15,7 @@ type Result struct {
 	Message              string            `json:"message"`
 	Duration             int64             `json:"duration"`
 	Source               string            `json:"source"`
-	HTTPError            string            `json:"http-error"`
-	HTTPStatusCode       int64             `json:"http-status-code"`
+	Annotations          map[string]string `json:"annotations"`
 }
 
 // Equals implements Equals for Result
@@ -41,7 +41,7 @@ func (r Result) Equals(v Result) bool {
 	if r.Source != v.Source {
 		return false
 	}
-	if r.HTTPStatusCode != v.HTTPStatusCode {
+	if eq := reflect.DeepEqual(r.Annotations, v.Annotations); eq == false {
 		return false
 	}
 	if len(r.Labels) != len(v.Labels) {
@@ -62,6 +62,7 @@ func NewResult(healthcheck Healthcheck, duration int64, eErr ExecutionError) *Re
 	if healthcheck.Base().Source != "" {
 		source = healthcheck.Base().Source
 	}
+
 	result := Result{
 		Name:                 healthcheck.Base().Name,
 		Summary:              healthcheck.Summary(),
@@ -69,7 +70,7 @@ func NewResult(healthcheck Healthcheck, duration int64, eErr ExecutionError) *Re
 		HealthcheckTimestamp: now.Unix(),
 		Duration:             duration,
 		Source:               source,
-		HTTPStatusCode:       int64(eErr.HTTPStatusCode),
+		Annotations:          eErr.Annotations,
 	}
 	if eErr.Error != nil {
 		result.Success = false

--- a/healthcheck/root.go
+++ b/healthcheck/root.go
@@ -34,8 +34,8 @@ type Healthcheck interface {
 }
 
 type ExecutionError struct {
-	Error          error
-	HTTPStatusCode int
+	Error       error
+	Annotations map[string]string
 }
 
 // Component is the component which will manage healthchecks

--- a/healthcheck/root.go
+++ b/healthcheck/root.go
@@ -25,12 +25,17 @@ type Healthcheck interface {
 	Initialize() error
 	GetConfig() interface{}
 	Summary() string
-	Execute() error
+	Execute() ExecutionError
 	LogDebug(message string)
 	LogInfo(message string)
 	Base() Base
 	SetSource(source string)
 	LogError(err error, message string)
+}
+
+type ExecutionError struct {
+	Error          error
+	HTTPStatusCode int
 }
 
 // Component is the component which will manage healthchecks
@@ -54,12 +59,12 @@ func (c *Component) startWrapper(w *Wrapper) {
 		time.Sleep(time.Duration(wait) * time.Millisecond)
 		for {
 			start := time.Now()
-			err := w.healthcheck.Execute()
+			eErr := w.healthcheck.Execute()
 			duration := time.Since(start)
 			result := NewResult(
 				w.healthcheck,
 				duration.Milliseconds(),
-				err)
+				eErr)
 			status := "failure"
 			if result.Success {
 				status = "success"

--- a/healthcheck/tcp.go
+++ b/healthcheck/tcp.go
@@ -129,15 +129,15 @@ func (h *TCPHealthcheck) LogInfo(message string) {
 }
 
 // Execute executes an healthcheck on the given target
-func (h *TCPHealthcheck) Execute() error {
-	h.LogDebug("start executing healthcheck")
+func (h *TCPHealthcheck) Execute() ExecutionError {
+	h.LogDebug("start executing healthcheckExecutionError")
 	ctx := h.t.Context(context.TODO())
 	dialer := net.Dialer{}
 	if h.Config.SourceIP != nil {
 		srcIP := net.IP(h.Config.SourceIP).String()
 		addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:0", srcIP))
 		if err != nil {
-			return errors.Wrapf(err, "Fail to set the source IP %s", srcIP)
+			return ExecutionError{Error: errors.Wrapf(err, "Fail to set the source IP %s", srcIP)}
 		}
 		dialer = net.Dialer{
 			LocalAddr: addr,
@@ -149,15 +149,15 @@ func (h *TCPHealthcheck) Execute() error {
 	if h.Config.ShouldFail {
 		if err == nil {
 			defer conn.Close()
-			return fmt.Errorf("TCP check is successful on %s but an error was expected", h.URL)
+			return ExecutionError{Error: fmt.Errorf("TCP check is successful on %s but an error was expected", h.URL)}
 		}
 	} else {
 		if err != nil {
-			return errors.Wrapf(err, "TCP connection failed on %s", h.URL)
+			return ExecutionError{Error: errors.Wrapf(err, "TCP connection failed on %s", h.URL)}
 		}
 		defer conn.Close()
 	}
-	return nil
+	return ExecutionError{Error: nil}
 }
 
 // NewTCPHealthcheck creates a TCP healthcheck from a logger and a configuration

--- a/healthcheck/tcp_test.go
+++ b/healthcheck/tcp_test.go
@@ -47,9 +47,9 @@ func TestTCPExecuteSuccess(t *testing.T) {
 		},
 	}
 	h.buildURL()
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 }
 
@@ -73,9 +73,9 @@ func TestTCPExecuteSuccessSourceIP(t *testing.T) {
 		},
 	}
 	h.buildURL()
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 }
 
@@ -106,9 +106,9 @@ func TestTCPv6ExecuteSuccess(t *testing.T) {
 		},
 	}
 	h.buildURL()
-	err = h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 }
 
@@ -155,8 +155,8 @@ func TestTCPExecuteSuccessShoulddFail(t *testing.T) {
 		},
 	}
 	h.buildURL()
-	err := h.Execute()
-	if err != nil {
-		t.Fatalf("healthcheck error :\n%v", err)
+	eErr := h.Execute()
+	if eErr.Error != nil {
+		t.Fatalf("healthcheck error :\n%v", eErr.Error)
 	}
 }

--- a/healthcheck/tls_test.go
+++ b/healthcheck/tls_test.go
@@ -44,8 +44,8 @@ func TestTLSExecuteError(t *testing.T) {
 		},
 	}
 	h.buildURL()
-	err = h.Execute()
-	if err == nil {
+	eErr := h.Execute()
+	if eErr.Error == nil {
 		t.Fatalf("Was expecting an error")
 	}
 }
@@ -60,8 +60,8 @@ func TestTLSExecuteErrorNoTarget(t *testing.T) {
 		},
 	}
 	h.buildURL()
-	err := h.Execute()
-	if err == nil {
+	eErr := h.Execute()
+	if eErr.Error == nil {
 		t.Fatalf("Was expecting an error")
 	}
 }

--- a/http/assets/index.html
+++ b/http/assets/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Cabourotte</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
+    <link rel="stylesheet" href="bulma.min.css">
     <style>
       .healthcheck {
           border: 1px dashed grey;
@@ -54,6 +54,7 @@
             <li><b>Source</b>: {{.Source }}</li>
             <li><b>Timestamp</b>: {{ formatts .HealthcheckTimestamp }}</li>
             <li><b>Duration</b>: {{ .Duration }} milliseconds</li>
+            {{ if ne .HTTPStatusCode 0 }}<li><b>HTTP Status Code</b>: {{ .HTTPStatusCode }}</li>{{ end }}
           </ul>
             {{ if .Labels }}<br/>
             {{ range $key, $value := .Labels }}

--- a/http/assets/index.html
+++ b/http/assets/index.html
@@ -54,7 +54,11 @@
             <li><b>Source</b>: {{.Source }}</li>
             <li><b>Timestamp</b>: {{ formatts .HealthcheckTimestamp }}</li>
             <li><b>Duration</b>: {{ .Duration }} milliseconds</li>
-            {{ if ne .HTTPStatusCode 0 }}<li><b>HTTP Status Code</b>: {{ .HTTPStatusCode }}</li>{{ end }}
+            {{ if .Annotations }}
+            {{ range $key, $value := .Annotations }}
+            <li><b>{{ $key }}</b>: {{ $value }}</li>
+            {{ end }}
+            {{ end }}
           </ul>
             {{ if .Labels }}<br/>
             {{ range $key, $value := .Labels }}


### PR DESCRIPTION
This PR contains 1 enhancement + 1 bug fix.

# Enhancement

The results now contains the `HTTP Status Code` for the http probes, it allows to display it in the card of the UI:

![image](https://github.com/user-attachments/assets/1b3fad8b-e748-48f0-b34b-d79f3831720a)

This is more convenient than expanding the error message, and allows to search for particular error codes in the JSON results.

# Bug fix

Any request to a not present asset crashes cabourotte with a panic (`fatal error: stack overflow`):

```
{"level":"info","ts":1733926719.405267,"caller":"http/handler.go:310","msg":"tt.html"}
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc020554388 stack=[0xc020554000, 0xc040554000]
fatal error: stack overflow

runtime stack:
runtime.throw({0xad87b6?, 0x47c02d?})
	/usr/lib/go/src/runtime/panic.go:1067 +0x48 fp=0x75e0609b9d00 sp=0x75e0609b9cd0 pc=0x4725c8
runtime.newstack()
	/usr/lib/go/src/runtime/stack.go:1117 +0x5bd fp=0x75e0609b9e40 sp=0x75e0609b9d00 pc=0x4566dd
runtime.morestack()
	/usr/lib/go/src/runtime/asm_amd64.s:621 +0x7a fp=0x75e0609b9e48 sp=0x75e0609b9e40 pc=0x4787ba

goroutine 19 gp=0xc000104700 m=7 mp=0xc000100708 [running]:
strings.Join({0xc000512250?, 0x1?, 0x1?}, {0xacd0ed?, 0x3?})
	/usr/lib/go/src/strings/strings.go:428 +0x465 fp=0xc020554398 sp=0xc020554390 pc=0x5334a5
github.com/mcorbin/corbierror.(*Error).Error(0xc000036740)
	/home/thomas/src/github.com/cabourotte/vendor/github.com/mcorbin/corbierror/error.go:27 +0x36 fp=0xc0205543e0 sp=0xc020554398 pc=0x93a636
github.com/mcorbin/corbierror.(*Error).Error(0xc000036740)
	/home/thomas/src/github.com/cabourotte/vendor/github.com/mcorbin/corbierror/error.go:29 +0x4a fp=0xc020554428 sp=0xc0205543e0 pc=0x93a64a
github.com/mcorbin/corbierror.(*Error).Error(0xc000036740)
	/home/thomas/src/github.com/cabourotte/vendor/github.com/mcorbin/corbierror/error.go:29 +0x4a fp=0xc020554470 sp=0xc020554428 pc=0x93a64a
github.com/mcorbin/corbierror.(*Error).Error(0xc000036740)
```

How to reproduce: Call anything in the path `/frontend/` except `index.html`.

I changed the method to manage the embedded assets, the missing files are now returning `404 Not Found`. It allows also to use any file in the `assets` folder, like `bulma.min.css` which was there but not used.
